### PR TITLE
Add font infrastructure and simple build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+CC=gcc
+CFLAGS=-Iinc -Wall -Wextra -std=c99
+OBJ=src/main.o src/bme280.o src/ssd1306.o src/fonts.o
+
+all: main
+
+main: $(OBJ)
+	$(CC) $(OBJ) -o $@
+
+src/%.o: src/%.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJ) main

--- a/inc/fonts.h
+++ b/inc/fonts.h
@@ -1,0 +1,14 @@
+#ifndef FONTS_H
+#define FONTS_H
+
+#include <stdint.h>
+
+typedef struct {
+    uint8_t width;
+    uint8_t height;
+    const uint16_t *data;
+} FontDef;
+
+extern const FontDef Font_7x10;
+
+#endif /* FONTS_H */

--- a/inc/stm32f4xx_hal.h
+++ b/inc/stm32f4xx_hal.h
@@ -1,0 +1,36 @@
+#ifndef STM32F4XX_HAL_H
+#define STM32F4XX_HAL_H
+
+#include <stdint.h>
+
+typedef struct {
+    void* Instance;
+    struct {
+        uint32_t ClockSpeed;
+        uint32_t DutyCycle;
+        uint32_t OwnAddress1;
+        uint32_t AddressingMode;
+        uint32_t DualAddressMode;
+        uint32_t OwnAddress2;
+        uint32_t GeneralCallMode;
+        uint32_t NoStretchMode;
+    } Init;
+} I2C_HandleTypeDef;
+
+#define I2C_DUTYCYCLE_2 0
+#define I2C_ADDRESSINGMODE_7BIT 0
+#define I2C_DUALADDRESS_DISABLE 0
+#define I2C_GENERALCALL_DISABLE 0
+#define I2C_NOSTRETCH_DISABLE 0
+#define I2C1 ((void*)0)
+
+#define HAL_MAX_DELAY 0xFFFFFFFFU
+
+static inline void HAL_I2C_Init(I2C_HandleTypeDef *hi2c) {(void)hi2c;}
+static inline void HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t devAddr, uint16_t memAddr, uint16_t memAddSize, uint8_t *pData, uint16_t size, uint32_t timeout) {
+    (void)hi2c; (void)devAddr; (void)memAddr; (void)memAddSize; (void)pData; (void)size; (void)timeout;
+}
+static inline void HAL_Delay(uint32_t ms) {(void)ms;}
+static inline void HAL_Init(void) {}
+
+#endif /* STM32F4XX_HAL_H */

--- a/src/fonts.c
+++ b/src/fonts.c
@@ -1,0 +1,10 @@
+#include "fonts.h"
+
+/* Simple placeholder font data: 95 characters, 10 lines each */
+static const uint16_t Font7x10_Table[95 * 10] = {0};
+
+const FontDef Font_7x10 = {
+    .width = 7,
+    .height = 10,
+    .data = Font7x10_Table
+};

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,8 @@
 #include "stm32f4xx_hal.h"
 #include "bme280.h"
 #include "ssd1306.h"
+#include "fonts.h"
+#include <stdio.h>
 
 I2C_HandleTypeDef hi2c1;
 
@@ -28,11 +30,11 @@ int main(void)
 
         SSD1306_Clear();
         snprintf(buffer, sizeof(buffer), "T: %.2f C", temp);
-        SSD1306_DrawString(0, 0, buffer, Font_7x10, White);
+        SSD1306_DrawString(0, 0, buffer, &Font_7x10, White);
         snprintf(buffer, sizeof(buffer), "H: %.2f %%", hum);
-        SSD1306_DrawString(0, 12, buffer, Font_7x10, White);
+        SSD1306_DrawString(0, 12, buffer, &Font_7x10, White);
         snprintf(buffer, sizeof(buffer), "P: %.2f hPa", pres);
-        SSD1306_DrawString(0, 24, buffer, Font_7x10, White);
+        SSD1306_DrawString(0, 24, buffer, &Font_7x10, White);
         SSD1306_UpdateScreen();
 
         HAL_Delay(1000);


### PR DESCRIPTION
## Summary
- declare `FontDef` and `Font_7x10` in new `fonts.h`
- provide minimal bitmap storage in `fonts.c`
- add stub `stm32f4xx_hal.h` for building on host
- include the new font in `main.c`
- introduce a small Makefile for local compilation

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6859971ae85083209715c4e63793608e